### PR TITLE
Do not ignore UL-CCCH messages in LTE for ext_header_ver 26

### DIFF
--- a/modules/pcap_dump.py
+++ b/modules/pcap_dump.py
@@ -265,7 +265,7 @@ class PcapDumper(DecodedSibsDumper):
             # - https://github.com/wireshark/wireshark/blob/wireshark-2.5.0/epan/dissectors/packet-gsmtap.h
             # - http://osmocom.org/projects/baseband/wiki/GSMTAP
             
-            if channel_type in (254, 255, RRCLOG_EXTENSION_SIB, RRCLOG_SIB_CONTAINER):
+            if channel_type in (254, 255):
                 return # Frames containing only a MIB or extension SIB, as already present in RRC frames, ignoring
             
             if LTE_UL_DCCH_NB < channel_type <= LTE_UL_DCCH_NB + 9:


### PR DESCRIPTION
In LTE, for ext_header_ver 26, UL-CCCH messages (e.g., RRC Connection Request) are ignored.

This is because the channel type for those messages is 10 and this is ignored because it's a RRCLOG_SIB_CONTAINER. I believe this is a mistake since they apply for 3G only.

Therefore, I removed the check for those channel types. Potentially the check for the channel types 254 and 255 can also be removed but I'm not entirely sure so I kept those in.