### PR TITLE
Added DIAG_QSR4_EXT_MSG_TERSE_F to the list of messaging opcodes.

### DIFF
--- a/inputs/_base_input.py
+++ b/inputs/_base_input.py
@@ -368,7 +368,7 @@ class BaseInput:
             
             self.dispatch_received_diag_packet(payload[7:])
         
-        elif opcode in (DIAG_MSG_F, DIAG_EXT_MSG_F, DIAG_EXT_MSG_TERSE_F, DIAG_QSR_EXT_MSG_TERSE_F): # This is a "message" string
+        elif opcode in (DIAG_MSG_F, DIAG_EXT_MSG_F, DIAG_EXT_MSG_TERSE_F, DIAG_QSR_EXT_MSG_TERSE_F, DIAG_QSR4_EXT_MSG_TERSE_F): # This is a "message" string
             
             self.dispatch_diag_message(opcode, payload)
         


### PR DESCRIPTION
Previously, it was being handled as a DIAG response, which caused qcsuper to fail to start. Tested by running `./qcsuper.py --adb --wireshark-live` with a rooted Pixel 3