### PR TITLE
Added TCP connector

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ $ sudo ./qcsuper.py --usb-modem /dev/ttyHS2 --wireshark-live
 Here is the current usage notice for QCSuper:
 
 ```
-usage: qcsuper.py [-h] [--cli] [--efs-shell] [-v] (--adb | --adb-wsl2 ADB_WSL2 | --usb-modem TTY_DEV | --dlf-read DLF_FILE | --json-geo-read JSON_FILE) [--info]
+usage: qcsuper.py [-h] [--cli] [--efs-shell] [-v] (--adb | --adb-wsl2 ADB_WSL2 | --tcp IP_ADDRESS:TCP_PORT --usb-modem TTY_DEV | --dlf-read DLF_FILE | --json-geo-read JSON_FILE) [--info]
                   [--pcap-dump PCAP_FILE] [--wireshark-live] [--memory-dump OUTPUT_DIR] [--dlf-dump DLF_FILE] [--json-geo-dump JSON_FILE] [--decoded-sibs-dump]
                   [--reassemble-sibs] [--decrypt-nas] [--include-ip-traffic] [--start MEMORY_START] [--stop MEMORY_STOP]
 
@@ -203,6 +203,8 @@ Input mode:
 
   --adb                 Use a rooted Android phone with USB debugging enabled as input (requires adb).
   --adb-wsl2 ADB_WSL2   Unix path to the Windows adb executable. Equivalent of --adb command but with WSL2/Windows interoperability.
+  --tcp IP_ADDRESS:TCP_PORT
+                        Connect to remote TCP service exposing DIAG interface.
   --usb-modem TTY_DEV   Use an USB modem exposing a DIAG pseudo-serial port through USB.
                         Possible syntaxes:
                           - "auto": Use the first device interface in the system found where the
@@ -376,6 +378,7 @@ Please note that only one client may communicate with the Diag port at the same 
 
 If ModemManager is active on your system, QCSuper will attempt to dynamically add an udev rule to prevent it to access the Diag port and restart its daemon, as it's currently the best way to achieve this. It will suppress this rule when closed.
 
+
 ## Supported devices
 
 QCSuper was successfully tested with:
@@ -391,6 +394,8 @@ QCSuper was successfully tested with:
 * OnePlus One and 3 (Phones)
 * Andromax A16C3H (Phone)
 * Samsung Galaxy S4 GT-I9505 (Phone)
+* Virtual Access GW1150 - using TCP connection
+* Westermo Merlin 4600 - using TCP connection
 
 Is it however aiming to be compatible with the widest possible range of devices based on a Qualcomm chipset, for the capture part.
 

--- a/src/inputs/tcp_connector.py
+++ b/src/inputs/tcp_connector.py
@@ -1,0 +1,76 @@
+#!/usr/bin/python3
+#-*- encoding: Utf-8 -*-
+from socket import socket, AF_INET, SOCK_STREAM
+from logging import debug, error, info, warning
+from ._hdlc_mixin import HdlcMixin
+from ._base_input import BaseInput
+
+"""
+    This class implements reading Qualcomm DIAG data from a remote TCP service.
+"""
+
+class TcpConnector(HdlcMixin, BaseInput):
+    
+    def __init__(self, args):
+        
+        address, port = args.split(':')
+        self.socket = socket(AF_INET, SOCK_STREAM)
+
+        try:
+            self.socket.connect((address, int(port)))
+
+        except Exception:
+            error('Could not communicate with the DIAG device through TCP')
+            exit()
+
+        self.received_first_packet = False
+
+        self.packet_buffer = b''
+        
+        super().__init__()
+    
+    def send_request(self, packet_type, packet_payload):
+        raw_payload = self.hdlc_encapsulate(bytes([packet_type]) + packet_payload)
+
+        self.socket.send(raw_payload)
+    
+    def read_loop(self):
+        while True:
+
+            while self.TRAILER_CHAR not in self.packet_buffer:
+
+                # Read message from the TCP socket
+
+                socket_read = self.socket.recv(1024 * 1024 * 10)
+
+                self.packet_buffer += socket_read
+
+            while self.TRAILER_CHAR in self.packet_buffer:
+                # Parse frame
+
+                raw_payload, self.packet_buffer = self.packet_buffer.split(self.TRAILER_CHAR, 1)
+
+                # Decapsulate and dispatch
+
+                try:
+
+                    unframed_message = self.hdlc_decapsulate(
+                        payload = raw_payload + self.TRAILER_CHAR
+                    )
+
+                except self.InvalidFrameError:
+
+                    # The first packet that we receive over the Diag input may
+                    # be partial
+
+                    continue
+
+                finally:
+
+                    self.received_first_packet = True
+
+                self.dispatch_received_diag_packet(unframed_message)
+ 
+    def __del__(self):
+        self.socket.close()
+    

--- a/src/main.py
+++ b/src/main.py
@@ -23,6 +23,7 @@ from .inputs.usb_modem_argparser import UsbModemArgParser, UsbModemArgType
 from .inputs.dlf_read import DlfReader
 from .inputs.adb import AdbConnector
 from .inputs.adb_wsl2 import AdbWsl2Connector
+from .inputs.tcp_connector import TcpConnector
 
 def main():
 
@@ -41,6 +42,7 @@ def main():
 
     input_mode.add_argument('--adb', action = 'store_true', help = 'Use a rooted Android phone with USB debugging enabled as input (requires adb).')
     input_mode.add_argument('--adb-wsl2', action = 'store', default=None, help = 'Unix path to the Windows adb executable. Equivalent of --adb command but with WSL2/Windows interoperability.')
+    input_mode.add_argument('--tcp', action = 'store', metavar = 'IP_ADDRESS:TCP_PORT', help = 'Connect to remote TCP service exposing DIAG interface.')
     input_mode.add_argument('--usb-modem', metavar = 'TTY_DEV', help = 'Use an USB modem exposing a DIAG pseudo-serial port through USB.\n' +
         'Possible syntaxes:\n' +
         '  - "auto": Use the first device interface in the system found where the\n' +
@@ -110,6 +112,8 @@ def main():
                 diag_input = UsbModemPyserialConnector(usb_modem.chardev_if_mounted)
             else:
                 diag_input = UsbModemPyusbConnector(usb_modem)
+    elif args.tcp:
+        diag_input = TcpConnector(args.tcp)
     elif args.usb_modem:
         usb_arg = UsbModemArgParser(args.usb_modem)
         if not usb_arg.arg_type:


### PR DESCRIPTION
The TcpConnector class allows QCSuper to read the DIAG data from a remote TCP service similar to QXDM.