### PR TITLE
Named pipe and tshark support

### DIFF
--- a/processor.py
+++ b/processor.py
@@ -1,0 +1,18 @@
+import os
+
+def read_from_pipe(pipe_path='/tmp/tshark_pipe'):
+    if not os.path.exists(pipe_path):
+        print(f"Error: The named pipe {pipe_path} does not exist. Make sure that TsharkLive has created it.")
+        return
+
+    try:
+        with open(pipe_path, 'r') as pipe:
+            for line in pipe:
+                print(f"{line.strip()}")
+    except KeyboardInterrupt:
+        print("\n")
+    except Exception as e:
+        print(f"Error: {e}")
+
+if __name__ == "__main__":
+    read_from_pipe()

--- a/src/main.py
+++ b/src/main.py
@@ -66,7 +66,7 @@ def main():
     modules.add_argument('--info', action = 'store_true', help = 'Read generic information about the baseband device.')
     modules.add_argument('--pcap-dump', metavar = 'PCAP_FILE', type = FileType('ab'), help = 'Generate a PCAP file containing GSMTAP frames for 2G/3G/4G, to be loaded using Wireshark.')
     modules.add_argument('--tshark', action = 'store_true', help = 'Same as --pcap-dump, but directly spawn tshark.')
-    modules.add_argument('--analysis', action = 'store_true', help = 'Same as --pcap-dump, but send the output to a named pipe.')
+    modules.add_argument('--analyze', action = 'store_true', help = 'Same as --pcap-dump, but send the output to a named pipe.')
     modules.add_argument('--wireshark-live', action = 'store_true', help = 'Same as --pcap-dump, but directly spawn a Wireshark instance.')
     # modules.add_argument('--efs-dump', metavar = 'OUTPUT_DIR', help = 'Dump the internal EFS filesystem of the device.')
     modules.add_argument('--memory-dump', metavar = 'OUTPUT_DIR', help = 'Dump the memory of the device (may not or partially work with recent devices).')
@@ -75,7 +75,7 @@ def main():
         'To be used in combination with --adb.')
     modules.add_argument('--decoded-sibs-dump', action = 'store_true', help = 'Print decoded SIBs to stdout (experimental, requires pycrate).')
 
-    pcap_options = parser.add_argument_group(title = 'PCAP generation options', description = 'To be used along with --pcap-dump, --wireshark-live, --tshark or --analysis.')
+    pcap_options = parser.add_argument_group(title = 'PCAP generation options', description = 'To be used along with --pcap-dump, --wireshark-live, --tshark or --analyze.')
 
     pcap_options.add_argument('--reassemble-sibs', action = 'store_true', help = 'Include reassembled UMTS SIBs as supplementary frames, also embedded fragmented in RRC frames.')
     pcap_options.add_argument('--decrypt-nas', action = 'store_true', help = 'Include unencrypted LTE NAS as supplementary frames, also embedded ciphered in RRC frames.')
@@ -156,10 +156,10 @@ def main():
         if args.wireshark_live:
             from .modules.pcap_dump import WiresharkLive
             diag_input.add_module(WiresharkLive(diag_input, args.reassemble_sibs, args.decrypt_nas, args.include_ip_traffic))
-        if args.analysis and not args.tshark:
-            from .modules.pcap_dump import ExternalAnalysis
-            diag_input.add_module(ExternalAnalysis(diag_input, args.reassemble_sibs, args.decrypt_nas, args.include_ip_traffic))
-        if args.tshark and not args.analysis:
+        if args.analyze and not args.tshark:
+            from .modules.pcap_dump import ExternalAnalyze
+            diag_input.add_module(ExternalAnalyze(diag_input, args.reassemble_sibs, args.decrypt_nas, args.include_ip_traffic))
+        if args.tshark and not args.analyze:
             from .modules.pcap_dump import TsharkLive
             diag_input.add_module(TsharkLive(diag_input, args.reassemble_sibs, args.decrypt_nas, args.include_ip_traffic))
         if args.json_geo_dump:

--- a/src/modules/pcap_dump.py
+++ b/src/modules/pcap_dump.py
@@ -507,7 +507,7 @@ class PcapDumper(DecodedSibsDumper):
         if getattr(self, 'pcap_file', None):
             self.pcap_file.close()
 
-class ExternalAnalysis(PcapDumper):
+class ExternalAnalyze(PcapDumper):
     def __init__(self, diag_input, reassemble_sibs, decrypt_nas, include_ip_traffic):
         tshark = which('tshark')
         if not tshark:


### PR DESCRIPTION
Hello

I have added tshark support:
./qcsuper.py --usb-modem /dev/ttyUSB0 --tshark

Additionally, you can now use external scripts to analyze packages:
./qcsuper.py --usb-modem /dev/ttyUSB0 --analyze | python3 processor.py

processor.py example:

```
import os

def read_from_pipe(pipe_path='/tmp/tshark_pipe'):
    if not os.path.exists(pipe_path):
        print(f"Error: The named pipe {pipe_path} does not exist. Make sure that TsharkLive has created it.")
        return

    try:
        with open(pipe_path, 'r') as pipe:
            for line in pipe:
                print(f"{line.strip()}")
    except KeyboardInterrupt:
        print("\n")
    except Exception as e:
        print(f"Error: {e}")

if __name__ == "__main__":
    read_from_pipe()
```