### PR TITLE
Add `--messages-live` module to print MSG events

### DIFF
--- a/src/qcsuper/inputs/_base_input.py
+++ b/src/qcsuper/inputs/_base_input.py
@@ -15,6 +15,7 @@ from ..protocol.messages import *
 
 LOG_CONFIG_DISABLE_OP = 0
 
+MSG_EXT_SUBCMD_SET_RT_MASK = 4
 MSG_EXT_SUBCMD_SET_ALL_RT_MASKS = 5
 MSG_LVL_NONE = 0
 

--- a/src/qcsuper/main.py
+++ b/src/qcsuper/main.py
@@ -210,6 +210,18 @@ def main():
         description='To be used along with --messages-live.',
     )
 
+    def msg_filter(string):
+        parts = [int(x, 0) for x in string.split(':')]
+        if len(parts) == 1:
+            # Enable all mask bits
+            return [parts[0], 0xFFFFFFFF]
+        elif len(parts) == 2:
+            return parts
+        else:
+            raise ValueError(
+                'message filter must be in the format SUBSYS[:MASK]'
+            )
+
     messages_options.add_argument(
         '--qdb',
         metavar='QSHRINK_DB',
@@ -222,7 +234,13 @@ def main():
         action='store_true',
         help="Don't highlight argument values in bold even when a TTY is present.",
     )
-    # TODO: subsystem argument?
+    messages_options.add_argument(
+        '--msg-filter',
+        metavar='SUBSYS[:MASK]',
+        type=msg_filter,
+        action='append',
+        help='Enable messages for the given subsystem. Specify multiple times, or omit to show all messages.',
+    )
 
     args = parser.parse_args()
 
@@ -346,7 +364,12 @@ def main():
             diag_input.add_module(DlfDumper(diag_input, args.dlf_dump))
         if args.messages_live:
             diag_input.add_module(
-                MessagePrinter(diag_input, args.qdb or [], not args.no_style)
+                MessagePrinter(
+                    diag_input,
+                    args.qdb or [],
+                    args.msg_filter,
+                    not args.no_style,
+                )
             )
 
     # if args.efs_dump:

--- a/src/qcsuper/main.py
+++ b/src/qcsuper/main.py
@@ -13,6 +13,7 @@ from .modules.memory_dump import MemoryDumper
 from .modules.cli import CommandLineInterface
 from .modules.dlf_dump import DlfDumper
 from .modules.info import InfoRetriever
+from .modules.messages_live import MessagePrinter
 from .modules._utils import FileType
 
 from .inputs.json_geo_read import JsonGeoReader
@@ -159,6 +160,11 @@ def main():
         action='store_true',
         help='Print decoded SIBs to stdout (experimental, requires pycrate).',
     )
+    modules.add_argument(
+        '--messages-live',
+        action='store_true',
+        help='Print modem log messages to stdout.',
+    )
 
     pcap_options = parser.add_argument_group(
         title='PCAP generation options',
@@ -198,6 +204,20 @@ def main():
         default='ffffffff',
         help='Offset at which to stop to dump memory (hex number), by default ffffffff.',
     )
+
+    messages_options = parser.add_argument_group(
+        title='Modem log options',
+        description='To be used along with --messages-live.',
+    )
+
+    messages_options.add_argument(
+        '--qdb',
+        metavar='QSHRINK_DB',
+        type=FileType('rb'),
+        action='append',
+        help='Optional QShrink database of terse message strings. If specified multiple times, later files take precedence.',
+    )
+    # TODO: subsystem argument?
 
     args = parser.parse_args()
 
@@ -319,6 +339,8 @@ def main():
             diag_input.add_module(InfoRetriever(diag_input))
         if args.dlf_dump:
             diag_input.add_module(DlfDumper(diag_input, args.dlf_dump))
+        if args.messages_live:
+            diag_input.add_module(MessagePrinter(diag_input, args.qdb or []))
 
     # if args.efs_dump:
     #     raise NotImplementedError

--- a/src/qcsuper/main.py
+++ b/src/qcsuper/main.py
@@ -217,6 +217,11 @@ def main():
         action='append',
         help='Optional QShrink database of terse message strings. If specified multiple times, later files take precedence.',
     )
+    messages_options.add_argument(
+        '--no-style',
+        action='store_true',
+        help="Don't highlight argument values in bold even when a TTY is present.",
+    )
     # TODO: subsystem argument?
 
     args = parser.parse_args()
@@ -340,7 +345,9 @@ def main():
         if args.dlf_dump:
             diag_input.add_module(DlfDumper(diag_input, args.dlf_dump))
         if args.messages_live:
-            diag_input.add_module(MessagePrinter(diag_input, args.qdb or []))
+            diag_input.add_module(
+                MessagePrinter(diag_input, args.qdb or [], not args.no_style)
+            )
 
     # if args.efs_dump:
     #     raise NotImplementedError

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -5,6 +5,7 @@ import io
 from logging import warning, debug
 import re
 from struct import Struct, pack  # TODO: Clean up?
+import sys
 import uuid
 import zlib
 
@@ -76,9 +77,11 @@ def args_at_start(data, arg_size, num_args):
 
 
 class MessagePrinter:
-    def __init__(self, diag_input, qshrink_fds):
+    def __init__(self, diag_input, qshrink_fds, enable_style):
 
         self.diag_input = diag_input
+
+        self.enable_style = enable_style and sys.stdout.isatty()
 
         self.qdb = QdbFile()
         for fd in qshrink_fds:
@@ -158,10 +161,14 @@ class MessagePrinter:
     def log_message(self, ssid, ss_mask, line, file, string, args):
 
         try:
-            formatted = cprintf(string, args).decode('ascii', 'replace')
+            formatted = cprintf(string, args, self.bold).decode(
+                'ascii', 'replace'
+            )
         except IndexError:
             fallback_string = string.decode('ascii', 'replace')
-            formatted = f'{fallback_string} ← {self.debug_args(args)}'
+            formatted = (
+                f'{fallback_string} ← {self.bold(self.debug_args(args))}'
+            )
 
         # Replace newlines with a glyph so that each message appears on a single line
         formatted = formatted.replace('\n', '⏎')
@@ -170,6 +177,13 @@ class MessagePrinter:
         line_spec = f'{file}:{line}'
 
         print(f'[{ssid:5}] {line_spec:44} {formatted}')
+
+    def bold(self, text):
+
+        if self.enable_style:
+            return f'\x1b[1m{text}\x1b[0m'
+        else:
+            return text
 
     @staticmethod
     def debug_args(args):
@@ -293,7 +307,7 @@ PRINTF_CONV = [
 ]
 
 
-def cprintf(fmt, args):
+def cprintf(fmt, args, arg_styler=lambda x: x):
 
     result = bytearray()
     pos = 0
@@ -372,7 +386,9 @@ def cprintf(fmt, args):
             py_conv = conv.decode('ascii')
 
             val = int.from_bytes(args.pop(), 'little', signed=signed)
-            formatted = f'%{py_flags}{py_width}{py_precision}{py_conv}' % val
+            formatted = arg_styler(
+                f'%{py_flags}{py_width}{py_precision}{py_conv}' % val
+            )
 
             result.extend(formatted.encode('ascii'))
         elif conv == b'%':
@@ -383,7 +399,7 @@ def cprintf(fmt, args):
             py_conv = conv.decode('ascii')
 
             val = int.from_bytes(args.pop(), 'little', signed=False)
-            formatted = f'%{py_conv}[{val:#010x}]'
+            formatted = arg_styler(f'%{py_conv}[{val:#010x}]')
 
             result.extend(formatted.encode('ascii'))
 

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -57,20 +57,6 @@ class Qsr4TerseMeta(
     STRUCT = Struct('<IH')
 
 
-def args_at_start(data, arg_size, num_args):
-
-    args_size = arg_size * num_args
-
-    if args_size == 0:
-        return [], data
-
-    # TODO: Catch too few bytes
-    args = [data[i : i + arg_size] for i in range(0, args_size, arg_size)]
-    rest = data[args_size:]
-
-    return args, rest
-
-
 """
     This module collects, formats, and prints modem debugging logs sourced from
     diag MSG events.
@@ -199,6 +185,7 @@ class MessagePrinter:
 
     @staticmethod
     def debug_args(args):
+
         values = ', '.join(
             f'{int.from_bytes(arg, "little", signed=False):#010x}'
             for arg in args
@@ -326,7 +313,6 @@ def cprintf(fmt, args, arg_styler=lambda x: x):
 
     def take_int():
         nonlocal pos
-
         val = None
         while pos < len(fmt) and (c := chr(fmt[pos])).isdigit():
             val = ((val or 0) * 10) + int(c)
@@ -335,7 +321,6 @@ def cprintf(fmt, args, arg_styler=lambda x: x):
 
     def take_token(tokens):
         nonlocal pos
-
         for t in tokens:
             if fmt[pos : pos + len(t)] == t:
                 pos += len(t)
@@ -419,6 +404,20 @@ def cprintf(fmt, args, arg_styler=lambda x: x):
         raise IndexError('more arguments than format conversions')
 
     return result
+
+
+def args_at_start(data, arg_size, num_args):
+
+    args_size = arg_size * num_args
+
+    if args_size == 0:
+        return [], data
+
+    # TODO: Catch too few bytes
+    args = [data[i : i + arg_size] for i in range(0, args_size, arg_size)]
+    rest = data[args_size:]
+
+    return args, rest
 
 
 class ZlibReader(io.RawIOBase):

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -1,0 +1,246 @@
+#!/usr/bin/python3
+# -*- encoding: Utf-8 -*-
+from collections import namedtuple
+from logging import warning
+from struct import Struct, pack  # TODO: Clean up?
+
+from ..inputs._base_input import (
+    message_id_to_name,
+    MSG_EXT_SUBCMD_SET_ALL_RT_MASKS,
+)
+
+from ..protocol.messages import *
+
+
+class ParseableStruct:
+    @classmethod
+    def _parse(cls, data):
+        return cls._make(cls.STRUCT.unpack(data))
+
+    @classmethod
+    def _parse_start(cls, data):
+        parsed = cls._parse(data[: cls.STRUCT.size])
+        remainder = data[cls.STRUCT.size :]
+        return parsed, remainder
+
+
+# From https://github.com/osmocom/osmo-qcdiag/blob/5b01f0bedd70f0c0df589eba347a8580d510d737/src/protocol/protocol.h#L26-L33
+class MsgHeader(
+    ParseableStruct,
+    namedtuple('MsgHeader', ['ts_type', 'num_args', 'drop_cnt', 'timestamp']),
+):
+    STRUCT = Struct('<BBBQ')
+
+
+class NormalMeta(
+    ParseableStruct, namedtuple('NormalMeta', ['line', 'ssid', 'ss_mask'])
+):
+    STRUCT = Struct('<HHI')
+
+
+def args_at_start(data, arg_size, num_args):
+
+    args_size = arg_size * num_args
+
+    if args_size == 0:
+        return [], data
+
+    # TODO: Catch too few bytes
+    args = [data[i : i + arg_size] for i in range(0, args_size, arg_size)]
+    rest = data[args_size:]
+
+    return args, rest
+
+
+"""
+    This module collects, formats, and prints modem debugging logs sourced from
+    diag MSG events.
+"""
+
+
+class MessagePrinter:
+    def __init__(self, diag_input, qshrink_fds):
+
+        self.diag_input = diag_input
+
+    def on_init(self):
+
+        self.diag_input.send_recv(
+            DIAG_EXT_MSG_CONFIG_F,
+            pack('<BxxI', MSG_EXT_SUBCMD_SET_ALL_RT_MASKS, 0xFFFFFFFF),
+            accept_error=False,
+        )
+
+    def on_deinit(self):
+
+        self.diag_input.send_recv(
+            DIAG_EXT_MSG_CONFIG_F,
+            pack('<BxxI', MSG_EXT_SUBCMD_SET_ALL_RT_MASKS, 0),
+            accept_error=False,
+        )
+
+    """
+        Process a single message event, either terse or non-terse.
+    """
+
+    def on_message(self, opcode, payload):
+
+        hdr, data = MsgHeader._parse_start(payload)
+
+        if opcode == DIAG_EXT_MSG_F:
+            meta, rest = NormalMeta._parse_start(data)
+            args, rest = args_at_start(rest, 4, hdr.num_args)
+            string, file, _ = rest.split(b'\x00')
+
+            self.log_message(
+                meta.ssid, meta.ss_mask, meta.line, file, string, args
+            )
+        else:
+            warning(
+                f'Unhandled message opcode {message_id_to_name.get(opcode, opcode)}'
+            )
+
+    def log_message(self, ssid, ss_mask, line, file, string, args):
+
+        try:
+            formatted = cprintf(string, args).decode('ascii', 'replace')
+        except IndexError:
+            fallback_string = string.decode('ascii', 'replace')
+            fallback_args = ', '.join(
+                f'{int.from_bytes(arg, "little", signed=False):#010x}'
+                for arg in args
+            )
+
+            formatted = f'{fallback_string} ← [{fallback_args}]'
+
+        # Replace newlines with a glyph so that each message appears on a single line
+        formatted = formatted.replace('\n', '⏎')
+
+        file = file.decode('utf-8', 'replace')
+        line_spec = f'{file}:{line}'
+
+        print(f'[{ssid:5}] {line_spec:44} {formatted}')
+
+
+PRINTF_FLAG = [b'#', b'0', b'-', b' ', b'+']
+PRINTF_LENGTH = [b'hh', b'h', b'll', b'l', b'q', b'L', b'j', b'z', b'Z', b't']
+PRINTF_CONV = [
+    b'd',
+    b'i',
+    b'o',
+    b'u',
+    b'x',
+    b'X',
+    b'e',
+    b'E',
+    b'f',
+    b'F',
+    b'g',
+    b'G',
+    b'a',
+    b'A',
+    b'c',
+    b's',
+    b'p',
+    b'%',
+]
+
+
+def cprintf(fmt, args):
+
+    result = bytearray()
+    pos = 0
+
+    def take_int():
+        nonlocal pos
+
+        val = None
+        while pos < len(fmt) and (c := chr(fmt[pos])).isdigit():
+            val = ((val or 0) * 10) + int(c)
+            pos += 1
+        return val
+
+    def take_token(tokens):
+        nonlocal pos
+
+        for t in tokens:
+            if fmt[pos : pos + len(t)] == t:
+                pos += len(t)
+                return t
+        return None
+
+    def take_repeated_tokens(tokens):
+        res = set()
+        while (t := take_token(tokens)) is not None:
+            res.add(t)
+        return res
+
+    # For efficient pop()ing
+    args.reverse()
+
+    while pos < len(fmt):
+        try:
+            conv_start = fmt.index(b'%', pos)
+        except ValueError:
+            result.extend(fmt[pos:])
+            break
+
+        result.extend(fmt[pos:conv_start])
+        pos = conv_start + 1
+
+        flags = take_repeated_tokens(PRINTF_FLAG)
+        width = take_int()
+        if take_token((b'.',)):
+            precision = take_token((b'*',)) or take_int()
+        else:
+            precision = None
+        length = take_token(PRINTF_LENGTH)
+        conv = take_token(PRINTF_CONV)
+
+        if conv is None:
+            # Malformed. Unroll and treat as literal.
+            pos = conv_start + 1
+            result.extend(b'%')
+            continue
+
+        if precision == b'#':
+            precision = int.from_bytes(args.pop(), 'little', signed=True)
+            if precision < 0:
+                precision = None
+
+        # TODO: Trim args based on length?
+
+        signed = False
+        if conv == b'p':
+            flags.add(b'#')
+            conv = b'x'
+        elif conv in (b'd', b'i'):
+            signed = True
+            conv = b'u'
+
+        if conv in (b'u', b'o', b'x', b'X', b'c'):
+            py_flags = b''.join(flags).decode('ascii')
+            py_width = str(width) if width is not None else ''
+            py_precision = f'.{precision}' if precision is not None else ''
+            py_conv = conv.decode('ascii')
+
+            val = int.from_bytes(args.pop(), 'little', signed=signed)
+            formatted = f'%{py_flags}{py_width}{py_precision}{py_conv}' % val
+
+            result.extend(formatted.encode('ascii'))
+        elif conv == b'%':
+            result.extend(b'%')
+        else:
+            # The Qualcomm arg list doesn't really support non-integral types,
+            # so just print the raw conversion specifier and argument value.
+            py_conv = conv.decode('ascii')
+
+            val = int.from_bytes(args.pop(), 'little', signed=False)
+            formatted = f'%{py_conv}[{val:#010x}]'
+
+            result.extend(formatted.encode('ascii'))
+
+    if len(args):
+        raise IndexError('more arguments than format conversions')
+
+    return result

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -11,6 +11,7 @@ import zlib
 
 from ..inputs._base_input import (
     message_id_to_name,
+    MSG_EXT_SUBCMD_SET_RT_MASK,
     MSG_EXT_SUBCMD_SET_ALL_RT_MASKS,
 )
 
@@ -77,10 +78,11 @@ def args_at_start(data, arg_size, num_args):
 
 
 class MessagePrinter:
-    def __init__(self, diag_input, qshrink_fds, enable_style):
+    def __init__(self, diag_input, qshrink_fds, msg_filters, enable_style):
 
         self.diag_input = diag_input
 
+        self.msg_filters = msg_filters
         self.enable_style = enable_style and sys.stdout.isatty()
 
         self.qdb = QdbFile()
@@ -89,11 +91,21 @@ class MessagePrinter:
 
     def on_init(self):
 
-        self.diag_input.send_recv(
-            DIAG_EXT_MSG_CONFIG_F,
-            pack('<BxxI', MSG_EXT_SUBCMD_SET_ALL_RT_MASKS, 0xFFFFFFFF),
-            accept_error=False,
-        )
+        if self.msg_filters is None:
+            self.diag_input.send_recv(
+                DIAG_EXT_MSG_CONFIG_F,
+                pack('<BxxI', MSG_EXT_SUBCMD_SET_ALL_RT_MASKS, 0xFFFFFFFF),
+                accept_error=False,
+            )
+        else:
+            for f in self.msg_filters:
+                self.diag_input.send_recv(
+                    DIAG_EXT_MSG_CONFIG_F,
+                    pack(
+                        '<BHHxxI', MSG_EXT_SUBCMD_SET_RT_MASK, f[0], f[0], f[1]
+                    ),
+                    accept_error=False,
+                )
 
     def on_deinit(self):
 

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -106,12 +106,7 @@ class MessagePrinter:
             formatted = cprintf(string, args).decode('ascii', 'replace')
         except IndexError:
             fallback_string = string.decode('ascii', 'replace')
-            fallback_args = ', '.join(
-                f'{int.from_bytes(arg, "little", signed=False):#010x}'
-                for arg in args
-            )
-
-            formatted = f'{fallback_string} ← [{fallback_args}]'
+            formatted = f'{fallback_string} ← {self.debug_args(args)}'
 
         # Replace newlines with a glyph so that each message appears on a single line
         formatted = formatted.replace('\n', '⏎')
@@ -120,6 +115,14 @@ class MessagePrinter:
         line_spec = f'{file}:{line}'
 
         print(f'[{ssid:5}] {line_spec:44} {formatted}')
+
+    @staticmethod
+    def debug_args(args):
+        values = ', '.join(
+            f'{int.from_bytes(arg, "little", signed=False):#010x}'
+            for arg in args
+        )
+        return f'[{values}]'
 
 
 PRINTF_FLAG = [b'#', b'0', b'-', b' ', b'+']

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -1,8 +1,12 @@
 #!/usr/bin/python3
 # -*- encoding: Utf-8 -*-
 from collections import namedtuple
-from logging import warning
+import io
+from logging import warning, debug
+import re
 from struct import Struct, pack  # TODO: Clean up?
+import uuid
+import zlib
 
 from ..inputs._base_input import (
     message_id_to_name,
@@ -38,6 +42,19 @@ class NormalMeta(
     STRUCT = Struct('<HHI')
 
 
+class TerseMeta(
+    ParseableStruct,
+    namedtuple('TerseMeta', ['line', 'ssid', 'ss_mask', 'hash']),
+):
+    STRUCT = Struct('<HHII')
+
+
+class Qsr4TerseMeta(
+    ParseableStruct, namedtuple('Qsr4TerseMeta', ['hash', 'magic'])
+):
+    STRUCT = Struct('<IH')
+
+
 def args_at_start(data, arg_size, num_args):
 
     args_size = arg_size * num_args
@@ -62,6 +79,10 @@ class MessagePrinter:
     def __init__(self, diag_input, qshrink_fds):
 
         self.diag_input = diag_input
+
+        self.qdb = QdbFile()
+        for fd in qshrink_fds:
+            self.qdb.parse(fd)
 
     def on_init(self):
 
@@ -88,7 +109,9 @@ class MessagePrinter:
         hdr, data = MsgHeader._parse_start(payload)
 
         if hdr.drop_cnt > 0:
-            warning(f"Dropped {hdr.drop_cnt} log message(s); consider adding filters")
+            warning(
+                f'Dropped {hdr.drop_cnt} log message(s); consider adding filters'
+            )
 
         if opcode == DIAG_EXT_MSG_F:
             meta, rest = NormalMeta._parse_start(data)
@@ -98,6 +121,35 @@ class MessagePrinter:
             self.log_message(
                 meta.ssid, meta.ss_mask, meta.line, file, string, args
             )
+        elif opcode == DIAG_QSR_EXT_MSG_TERSE_F:
+            meta, rest = TerseMeta._parse_start(data)
+            args, rest = args_at_start(rest, 4, hdr.num_args)
+
+            h = self.qdb.messages.get(meta.hash)
+            if h is not None:
+                self.log_message(
+                    meta.ssid, meta.ss_mask, meta.line, h.file, h.string, args
+                )
+            else:
+                warning(
+                    f'Unmapped terse message (try --qdb): {meta.hash}{self.debug_args(args)}'
+                )
+        elif opcode == DIAG_QSR4_EXT_MSG_TERSE_F:
+            meta, rest = Qsr4TerseMeta._parse_start(data)
+
+            arg_size = (hdr.num_args >> 4) & 0xF
+            num_args = (hdr.num_args >> 0) & 0xF
+            args, _ = args_at_start(rest, arg_size, num_args)
+
+            h = self.qdb.qsr4_messages.get(meta.hash)
+            if h is not None:
+                self.log_message(
+                    h.ssid, h.ss_mask, h.line, h.file, h.string, args
+                )
+            else:
+                warning(
+                    f'Unmapped terse message (try --qdb): {meta.hash}{self.debug_args(args)}'
+                )
         else:
             warning(
                 f'Unhandled message opcode {message_id_to_name.get(opcode, opcode)}'
@@ -126,6 +178,95 @@ class MessagePrinter:
             for arg in args
         )
         return f'[{values}]'
+
+
+class QdbFile:
+    HashedMessage = namedtuple('HashedMessage', ['hash', 'file', 'string'])
+    Qsr4HashedMessage = namedtuple(
+        'Qsr4HashedMessage',
+        ['hash', 'ss_mask', 'ssid', 'line', 'file', 'string'],
+    )
+
+    QDB_HEADER_SIZE = 0x40
+    TAG_REGEX = re.compile(rb'<(\w+)>(?:\s*(.*?)\s*<[\\/]\1>)?\s*')
+
+    def __init__(self):
+
+        self.messages = {}
+        self.qsr4_messages = {}
+
+    def parse(self, file):
+
+        qdb_header = file.read(self.QDB_HEADER_SIZE)
+        if len(qdb_header) == self.QDB_HEADER_SIZE and qdb_header.startswith(
+            b'\x7fQDB'
+        ):
+            # Compressed `.qdb` file
+            guid = uuid.UUID(bytes=qdb_header[4:20])
+            debug(f'Detected compressed .qdb file with GUID {guid}')
+
+            inner = io.BufferedReader(ZlibReader(file))
+            parsed = self.parse_uncompressed(inner)
+
+            # TODO: check GUID match
+        else:
+            # Not compressed, try to parse directly
+            file.seek(0)
+            parsed = self.parse_uncompressed(file)
+
+        debug(f'Parsed QDB {parsed}')
+        return parsed
+
+    def parse_uncompressed(self, file):
+
+        meta = {}
+
+        cur_tag = None
+        expected_close = None
+        for line in file:
+            line = line.rstrip(b'\n')
+            if not line or line.startswith(b'#'):
+                continue
+            elif cur_tag is not None and line.rstrip() in expected_close:
+                cur_tag = None
+                expected_close = None
+            elif cur_tag is None and (match := self.TAG_REGEX.fullmatch(line)):
+                tag, singleline_content = match.groups()
+                if singleline_content is not None:
+                    # Single-line tags contain file metadata
+                    meta[tag] = singleline_content
+                else:
+                    cur_tag = tag
+                    expected_close = [rb'<\%s>' % cur_tag, rb'</%s>' % cur_tag]
+            else:
+                self.process_line(cur_tag, line)
+
+        if cur_tag is not None:
+            raise ValueError('unclosed tag', cur_tag)
+
+        return meta
+
+    def process_line(self, tag, line):
+
+        if tag is None:
+            m = self.intify(self.HashedMessage, line.split(b':', 2), ('hash',))
+            self.messages[m.hash] = m
+        elif tag == b'Content':
+            m = self.intify(
+                self.Qsr4HashedMessage,
+                line.split(b':', 5),
+                ('hash', 'ss_mask', 'ssid', 'line'),
+            )
+            self.qsr4_messages[m.hash] = m
+
+    @staticmethod
+    def intify(tuple_type, tuple_values, to_convert):
+
+        mapped = (
+            int(v) if tuple_type._fields[i] in to_convert else v
+            for i, v in enumerate(tuple_values)
+        )
+        return tuple_type._make(mapped)
 
 
 PRINTF_FLAG = [b'#', b'0', b'-', b' ', b'+']
@@ -250,3 +391,33 @@ def cprintf(fmt, args):
         raise IndexError('more arguments than format conversions')
 
     return result
+
+
+class ZlibReader(io.RawIOBase):
+    def __init__(self, raw):
+
+        self.raw = raw
+        self.decompressor = zlib.decompressobj()
+
+    def readable(self):
+
+        return True
+
+    def readinto(self, buf):
+
+        if not len(buf):
+            return 0
+
+        compressed = self.decompressor.unconsumed_tail or self.raw.read(
+            io.DEFAULT_BUFFER_SIZE
+        )
+        decompressed = self.decompressor.decompress(compressed, len(buf))
+
+        buf[: len(decompressed)] = decompressed
+        return len(decompressed)
+
+    def close(self):
+
+        self.decompressor = None
+        self.raw.close()
+        return super().close()

--- a/src/qcsuper/modules/messages_live.py
+++ b/src/qcsuper/modules/messages_live.py
@@ -87,6 +87,9 @@ class MessagePrinter:
 
         hdr, data = MsgHeader._parse_start(payload)
 
+        if hdr.drop_cnt > 0:
+            warning(f"Dropped {hdr.drop_cnt} log message(s); consider adding filters")
+
         if opcode == DIAG_EXT_MSG_F:
             meta, rest = NormalMeta._parse_start(data)
             args, rest = args_at_start(rest, 4, hdr.num_args)


### PR DESCRIPTION
I believe this is one of the main features of QXDM, but there's very little open-source support for it. The only projects I'm aware of are [qc_debug_monitor](https://github.com/Cr4sh/qc_debug_monitor), which works well but doesn't support USB modems or the new Qshrink4 terse message format, and [nano-dm](https://github.com/kevinmehall/nano-dm), which I couldn't get to work at all because of many hardcoded chipset-specific command strings.

QCSuper seems to be the best-maintained open-source DIAG tool around, so including this feature seems natural. It does require a fair bit of new code, including 1) a custom printf implementation to recombine the format string and argument values exposed by the protocol, and 2) a parser for Qualcomm's Qshrink and Qshrink 4 database file formats, which contain out-of-band format strings for "terse" messages and can often be found in device GPL dumps.

The code's not quite ready to merge, but it's good enough to review. Here's a screenshot of what the output looks like for the command `./qcsuper.py --usb-modem 04e8:685d:1:2 --messages-live --qdb qdsp6m.qdb` on a Galaxy S10e, with `qdsp6m.qdb` sourced from the phone's GPL source:
<img width="1481" height="812" alt="2025-09-13T12:52:13,798646721-04:00" src="https://github.com/user-attachments/assets/1f00d052-d1ed-4632-ba43-1ba199cb87d5" />