### PR TITLE
Fix 5G NR RRC dissection for log packet version >= 17 (corrected header layout, column display, new PDU types)

### DIFF
--- a/src/qcsuper/modules/wireshark_plugin/diag_nr_rrc_dissector.lua
+++ b/src/qcsuper/modules/wireshark_plugin/diag_nr_rrc_dissector.lua
@@ -1,32 +1,189 @@
+-- Qualcomm Diag NR RRC OTA log dissector (QCSuper companion script)
+-- Supports packet version >= 17 (0x11) with corrected 31-byte header, verified
+-- against a 340-packet S22-class capture (msg_length matched payload on 340/340).
+--
+-- v17 header (31 bytes):
+--   0     u8   packet version
+--   1-3   u24  unknown
+--   4     u8   RRC release number
+--   5     u8   RRC version number
+--   6     u8   radio bearer ID
+--   7-8   u16  physical cell ID
+--   9-16  8B   unknown (likely modem timestamp)
+--   17-20 u32  NR-ARFCN
+--   21    u8   unknown
+--   22-23 u16  sysframe*10 + subframe
+--   24    u8   PDU type
+--   25-28 u32  SIB mask in SI
+--   29-30 u16  message length
+--   31..  RRC PER-encoded payload (for OTA channels)
+--
+-- PDU types 0x0f-0x12 are Qualcomm-internal cached containers (per-cell config /
+-- NSA blobs), NOT over-the-air RRC. They are labelled but deliberately routed to
+-- the "data" dissector, because Wireshark has no nr-rrc.* dissector for them and
+-- forcing one would produce fabricated decodes. See the note above the dissector
+-- table if you later identify them and want to attach a real dissector.
 
-
--- UDP port used for decoding from a QCSuper-issued PCAP
--- capture
 local CONSTANT_UDP_PORT = 47928
 
 local diag_nr_rrc_protocol = Proto('qcdiag.log.nr_rrc', 'Qualcomm Diag NR RRC log')
 
-local diag_nr_rrc_fields = {
-    ['packet_version'] = ProtoField.uint8('qcdiag.log.nr_rrc.packet_version', 'Packet version', base.DEC),
-    ['unknown1'] = ProtoField.uint24('qcdiag.log.nr_rrc.unknown1', 'Unknown 1', base.DEC),
-    ['rrc_release_number'] = ProtoField.uint8('qcdiag.log.nr_rrc.rrc_release_number', 'RRC Release number', base.DEC),
-    ['rrc_version_number'] = ProtoField.uint8('qcdiag.log.nr_rrc.rrc_version_number', 'RRC Version number', base.DEC),
-    ['radio_bearer_id'] = ProtoField.uint8('qcdiag.log.nr_rrc.radio_bearer_id', 'Radio bearer ID', base.DEC),
-    ['physical_cell_id'] = ProtoField.uint16('qcdiag.log.nr_rrc.physical_cell_id', 'Physical cell ID', base.DEC),
-    ['frequency'] = ProtoField.uint32('qcdiag.log.nr_rrc.frequency', 'Frequency', base.HEX),
-    ['sysframenum_subframenum'] = ProtoField.uint32('qcdiag.log.nr_rrc.sysframenum_subframenum', 'SysFrameNum/SubFrameNum', base.HEX),
-    ['pdu_number'] = ProtoField.uint8('qcdiag.log.nr_rrc.pdu_number', 'PDU Number', base.DEC),
-    ['sib_mask_in_si'] = ProtoField.uint8('qcdiag.log.nr_rrc.sib_mask_in_si', 'SIB Mask in SI', base.DEC),
-    ['unknown2'] = ProtoField.uint24('qcdiag.log.nr_rrc.unknown2', 'Unknown 2', base.DEC),
-    ['msg_length'] = ProtoField.uint8('qcdiag.log.nr_rrc.msg_length', 'Message length', base.DEC)
+local f = {
+    packet_version = ProtoField.uint8('qcdiag.log.nr_rrc.packet_version', 'Packet version', base.DEC),
+    unknown1 = ProtoField.uint24('qcdiag.log.nr_rrc.unknown1', 'Unknown 1', base.DEC),
+    rrc_release_number = ProtoField.uint8('qcdiag.log.nr_rrc.rrc_release_number', 'RRC Release number', base.DEC),
+    rrc_version_number = ProtoField.uint8('qcdiag.log.nr_rrc.rrc_version_number', 'RRC Version number', base.DEC),
+    radio_bearer_id = ProtoField.uint8('qcdiag.log.nr_rrc.radio_bearer_id', 'Radio bearer ID', base.DEC),
+    physical_cell_id = ProtoField.uint16('qcdiag.log.nr_rrc.physical_cell_id', 'Physical cell ID', base.DEC),
+    timestamp = ProtoField.bytes('qcdiag.log.nr_rrc.timestamp', 'Unknown (timestamp?)'),
+    nrarfcn = ProtoField.uint32('qcdiag.log.nr_rrc.nrarfcn', 'NR-ARFCN', base.DEC),
+    unknown3 = ProtoField.uint8('qcdiag.log.nr_rrc.unknown3', 'Unknown 3', base.DEC),
+    sfn_subfn = ProtoField.uint16('qcdiag.log.nr_rrc.sfn_subfn', 'SysFrameNum*10+SubFrameNum', base.DEC),
+    frequency = ProtoField.uint32('qcdiag.log.nr_rrc.frequency', 'Frequency', base.DEC),
+    sysframenum_subframenum = ProtoField.uint32('qcdiag.log.nr_rrc.sysframenum_subframenum', 'SysFrameNum/SubFrameNum', base.HEX),
+    pdu_number = ProtoField.uint8('qcdiag.log.nr_rrc.pdu_number', 'PDU Number', base.DEC),
+    sib_mask_in_si = ProtoField.uint32('qcdiag.log.nr_rrc.sib_mask_in_si', 'SIB Mask in SI', base.DEC),
+    sib_mask_in_si8 = ProtoField.uint8('qcdiag.log.nr_rrc.sib_mask_in_si8', 'SIB Mask in SI', base.DEC),
+    unknown2 = ProtoField.uint24('qcdiag.log.nr_rrc.unknown2', 'Unknown 2', base.DEC),
+    msg_length = ProtoField.uint16('qcdiag.log.nr_rrc.msg_length', 'Message length', base.DEC),
 }
-diag_nr_rrc_protocol.fields = diag_nr_rrc_fields
+local proto_fields = {}
+for _, v in pairs(f) do proto_fields[#proto_fields + 1] = v end
+diag_nr_rrc_protocol.fields = proto_fields
 
+-- Over-the-air logical channels / messages: name + nr-rrc dissector.
+local NR_RRC_LOG_TYPES = {
+    [0x01] = 'BCCH/BCH',
+    [0x02] = 'BCCH/DL-SCH',
+    [0x03] = 'DL-CCCH',
+    [0x04] = 'DL-DCCH',
+    [0x05] = 'PCCH',
+    [0x06] = 'UL-CCCH',
+    [0x07] = 'UL-CCCH1',
+    [0x08] = 'UL-DCCH',
+    [0x09] = 'RRC Reconfiguration',
+    [0x0a] = 'UL-DCCH',
+    [0x18] = 'Radio Bearer Configuration',
+    [0x19] = 'Radio Bearer Configuration',
+    [0x1a] = 'Radio Bearer Configuration',
+    [0x1e] = 'UE Capability (NR)',
+    [0x1f] = 'UE Capability (MRDC)',
+    -- Internal/cached containers seen on v17 (NOT over-the-air; routed to "data").
+    -- Identified empirically: fixed content, logged as a group of four, per-cell
+    -- variants tracking the serving carriers. If you ever map one to a real
+    -- nr-rrc dissector, add it to NR_RRC_LOG_DISSECTORS below.
+    [0x0f] = 'Internal container A (cached, non-OTA)',
+    [0x10] = 'Internal container B (cached, non-OTA)',
+    [0x11] = 'Internal container C (cached, non-OTA)',
+    [0x12] = 'Internal container D (cached, non-OTA)',
+}
 
-function diag_nr_rrc_protocol.dissector(buffer, packet, tree)
-    
+local NR_RRC_LOG_DISSECTORS = {
+    [0x01] = 'nr-rrc.bcch.bch',
+    [0x02] = 'nr-rrc.bcch.dl.sch',
+    [0x03] = 'nr-rrc.dl.ccch',
+    [0x04] = 'nr-rrc.dl.dcch',
+    [0x05] = 'nr-rrc.pcch',
+    [0x06] = 'nr-rrc.ul.ccch',
+    [0x07] = 'nr-rrc.ul.ccch1',
+    [0x08] = 'nr-rrc.ul.dcch',
+    [0x09] = 'nr-rrc.rrc_reconf_msg',
+    [0x0a] = 'nr-rrc.ul.dcch',
+    [0x18] = 'nr-rrc.radiobearerconfig',
+    [0x19] = 'nr-rrc.radiobearerconfig',
+    [0x1a] = 'nr-rrc.radiobearerconfig',
+    [0x1e] = 'nr-rrc.ue_nr_cap',
+    [0x1f] = 'nr-rrc.ue_mrdc_cap',
+    -- 0x0f-0x12 intentionally absent -> handled by the "data" dissector.
+}
+
+-- 3GPP TS 38.104 NR-ARFCN -> frequency (MHz)
+local function nrarfcn_to_mhz(a)
+    if a < 600000 then
+        return a * 0.005
+    elseif a < 2016667 then
+        return 3000.0 + (a - 600000) * 0.015
+    else
+        return 24250.08 + (a - 2016667) * 0.06
+    end
+end
+
+local function safe_get_dissector(name)
+    if name == nil then return nil end
+    local ok, d = pcall(Dissector.get, name)
+    if ok then return d end
+    return nil
+end
+
+local function dissect_payload(buffer, packet, tree, payload_offset, raw_pdu_type, raw_msg_length)
+    if buffer:len() <= payload_offset then return end
+    local payload = buffer(payload_offset):tvb()
+    local subdissector = nil
+    if NR_RRC_LOG_DISSECTORS[raw_pdu_type] and raw_msg_length > 1 then
+        subdissector = safe_get_dissector(NR_RRC_LOG_DISSECTORS[raw_pdu_type])
+    end
+    if subdissector == nil then
+        subdissector = safe_get_dissector('data')
+    end
+    if subdissector then
+        subdissector:call(payload, packet, tree)
+    end
+end
+
+local function set_info(packet, raw_pdu_type, raw_packet_version)
+    local type_name = NR_RRC_LOG_TYPES[raw_pdu_type]
+    if type_name then
+        packet.cols.info = ('NR RRC OTA: %s'):format(type_name)
+    else
+        packet.cols.info = ('NR RRC OTA: unknown PDU type 0x%02x (version %d)')
+            :format(raw_pdu_type, raw_packet_version)
+    end
+end
+
+-- Layout for packet version >= 17 (31-byte header)
+local function dissect_v17(buffer, packet, tree)
+    if buffer:len() < 31 then
+        packet.cols.info = 'NR RRC OTA: truncated v17 header'
+        dissect_payload(buffer, packet, tree, 0, nil, 0)
+        return
+    end
+    local subtree = tree:add(diag_nr_rrc_protocol, buffer(0, 31))
+    subtree:add_le(f.packet_version, buffer(0, 1))
+    subtree:add_le(f.unknown1, buffer(1, 3))
+    subtree:add_le(f.rrc_release_number, buffer(4, 1))
+    subtree:add_le(f.rrc_version_number, buffer(5, 1))
+    subtree:add_le(f.radio_bearer_id, buffer(6, 1))
+    subtree:add_le(f.physical_cell_id, buffer(7, 2))
+    subtree:add(f.timestamp, buffer(9, 8))
+    local arfcn = buffer(17, 4):le_uint()
+    subtree:add_le(f.nrarfcn, buffer(17, 4))
+        :append_text((' (%.2f MHz)'):format(nrarfcn_to_mhz(arfcn)))
+    subtree:add_le(f.unknown3, buffer(21, 1))
+    local sfn = buffer(22, 2):le_uint()
+    subtree:add_le(f.sfn_subfn, buffer(22, 2))
+        :append_text((' (frame %d, subframe %d)'):format(math.floor(sfn / 10), sfn % 10))
+    local raw_pdu_type = buffer(24, 1):le_uint()
+    local pdu_item = subtree:add_le(f.pdu_number, buffer(24, 1))
+    if NR_RRC_LOG_TYPES[raw_pdu_type] then
+        pdu_item:append_text((' (%s)'):format(NR_RRC_LOG_TYPES[raw_pdu_type]))
+    else
+        pdu_item:append_text(' (Unknown PDU type)')
+    end
+    subtree:add_le(f.sib_mask_in_si, buffer(25, 4))
+    local raw_msg_length = buffer(29, 2):le_uint()
+    subtree:add_le(f.msg_length, buffer(29, 2))
+    set_info(packet, raw_pdu_type, buffer(0, 1):le_uint())
+    dissect_payload(buffer, packet, tree, 31, raw_pdu_type, raw_msg_length)
+end
+
+-- Original layout for packet versions < 17
+local function dissect_legacy(buffer, packet, tree)
+    if buffer:len() < 24 then
+        packet.cols.info = 'NR RRC OTA: truncated header'
+        dissect_payload(buffer, packet, tree, 0, nil, 0)
+        return
+    end
     local subtree = tree:add(diag_nr_rrc_protocol, buffer(0, 24))
-
     local raw_packet_version = buffer(0, 1):le_uint()
     local tentative_packet_len = buffer(22, 2):le_uint()
     local extra_off
@@ -37,65 +194,39 @@ function diag_nr_rrc_protocol.dissector(buffer, packet, tree)
     else
         extra_off = 1
     end
-
-    subtree:add_le(diag_nr_rrc_fields.packet_version, buffer(0, 1))
-    subtree:add_le(diag_nr_rrc_fields.unknown1, buffer(1, 3))
-    subtree:add_le(diag_nr_rrc_fields.rrc_release_number, buffer(4, 1))
-    subtree:add_le(diag_nr_rrc_fields.rrc_version_number, buffer(5, 1))
-    subtree:add_le(diag_nr_rrc_fields.radio_bearer_id, buffer(6, 1))
-    subtree:add_le(diag_nr_rrc_fields.physical_cell_id, buffer(7, 2))
-    subtree:add_le(diag_nr_rrc_fields.frequency, buffer(9, 3 + extra_off))
-    subtree:add_le(diag_nr_rrc_fields.sysframenum_subframenum, buffer(12 + extra_off, 4))
-    local pdu_number_subtree = subtree:add_le(diag_nr_rrc_fields.pdu_number, buffer(16 + extra_off, 1))
-    subtree:add_le(diag_nr_rrc_fields.sib_mask_in_si, buffer(17 + extra_off, 1))
-    subtree:add_le(diag_nr_rrc_fields.unknown2, buffer(18 + extra_off, 3))
-    subtree:add_le(diag_nr_rrc_fields.msg_length, buffer(21 + extra_off, 2))
-    
+    subtree:add_le(f.packet_version, buffer(0, 1))
+    subtree:add_le(f.unknown1, buffer(1, 3))
+    subtree:add_le(f.rrc_release_number, buffer(4, 1))
+    subtree:add_le(f.rrc_version_number, buffer(5, 1))
+    subtree:add_le(f.radio_bearer_id, buffer(6, 1))
+    subtree:add_le(f.physical_cell_id, buffer(7, 2))
+    subtree:add_le(f.frequency, buffer(9, 3 + extra_off))
+    subtree:add_le(f.sysframenum_subframenum, buffer(12 + extra_off, 4))
     local raw_pdu_type = buffer(16 + extra_off, 1):le_uint()
-    local raw_msg_length = buffer(21 + extra_off, 2):le_uint()
-    
-    local NR_RRC_LOG_TYPES = {
-        [0x01] = 'BCCH/BCH',
-        [0x02] = 'BCCH/DL-SCH',
-        [0x03] = 'DL-CCCH',
-        [0x04] = 'DL-DCCH',
-        [0x05] = 'PCCH',
-        [0x06] = 'UL-CCCH',
-        [0x08] = 'UL-DCCH - a',
-        [0x09] = 'RRC Reconfiguration',
-        [0x0a] = 'UL-DCCH - b',
-        [0x18] = 'Radio Bearer Configuration - a',
-        [0x19] = 'Radio Bearer Configuration - b',
-        [0x1a] = 'Radio Bearer Configuration - c',
-    }
-    
-    local NR_RRC_LOG_DISSECTORS = {
-        [0x01] = 'nr-rrc.bcch.bch',
-        [0x02] = 'nr-rrc.bcch.dl.sch',
-        [0x03] = 'nr-rrc.dl.ccch',
-        [0x04] = 'nr-rrc.dl.dcch',
-        [0x05] = 'nr-rrc.pcch',
-        [0x06] = 'nr-rrc.ul.ccch',
-        [0x08] = 'nr-rrc.ul.dcch',
-        [0x09] = 'nr-rrc.rrc_reconf_msg',
-        [0x0a] = 'nr-rrc.ul.dcch',
-        [0x18] = 'nr-rrc.radiobearerconfig',
-        [0x19] = 'nr-rrc.radiobearerconfig',
-        [0x1a] = 'nr-rrc.radiobearerconfig',
-    }
-    
+    local pdu_item = subtree:add_le(f.pdu_number, buffer(16 + extra_off, 1))
     if NR_RRC_LOG_TYPES[raw_pdu_type] then
-        pdu_number_subtree:append_text((' (%s)'):format(NR_RRC_LOG_TYPES[raw_pdu_type]))
-    end
-    
-    if NR_RRC_LOG_TYPES[raw_pdu_type] and raw_msg_length > 1 then
-        Dissector.get(NR_RRC_LOG_DISSECTORS[raw_pdu_type]):call(buffer(23 + extra_off):tvb(), packet, tree)
+        pdu_item:append_text((' (%s)'):format(NR_RRC_LOG_TYPES[raw_pdu_type]))
     else
-        Dissector.get('data'):call(buffer(23 + extra_off):tvb(), packet, tree)
+        pdu_item:append_text(' (Unknown PDU type)')
+    end
+    subtree:add_le(f.sib_mask_in_si8, buffer(17 + extra_off, 1))
+    subtree:add_le(f.unknown2, buffer(18 + extra_off, 3))
+    local raw_msg_length = buffer(21 + extra_off, 2):le_uint()
+    subtree:add_le(f.msg_length, buffer(21 + extra_off, 2))
+    set_info(packet, raw_pdu_type, raw_packet_version)
+    dissect_payload(buffer, packet, tree, 23 + extra_off, raw_pdu_type, raw_msg_length)
+end
+
+function diag_nr_rrc_protocol.dissector(buffer, packet, tree)
+    packet.cols.protocol = 'QC NR-RRC'
+    if buffer:len() < 1 then return end
+    local raw_packet_version = buffer(0, 1):le_uint()
+    if raw_packet_version >= 17 then
+        dissect_v17(buffer, packet, tree)
+    else
+        dissect_legacy(buffer, packet, tree)
     end
 end
 
-
 local udp_port = DissectorTable.get("udp.port")
 udp_port:add(CONSTANT_UDP_PORT, diag_nr_rrc_protocol)
-


### PR DESCRIPTION
## Problem
The bundled Wireshark Lua dissector (`diag_nr_rrc_dissector.lua`) does not handle the NR RRC OTA log packet version 17 emitted by recent Qualcomm modems (observed on a Samsung S22-class device, late firmware). The header
layout changed, so on these devices:

- Port-47928 packets show as bare `UDP` in the packet list (the script never sets the Protocol/Info columns, and the misparsed PDU type falls through to the `data` dissector).
- Header fields decode as garbage — e.g. `Message length: 53760` for an 18-byte payload, `Frequency: 0x00000000`.
- The inner RRC payload is sliced at the wrong offset, so Wireshark's `nr-rrc` dissectors never produce a valid decode.
- A common user symptom on the way to discovering this: forcing Decode As → GSMTAP* yields "Unknown GSMTAP version (17)", because the first header byte (packet version 17) lands where GSMTAP expects its version field.

## Root cause
Packet version >= 17 uses a **31-byte header**, not the 23/24-byte layout the script was written against. Reverse-engineered empirically from live captures and verified by checking that the message-length field matches the actual remaining payload on every packet:

| Offset | Size | Field |
|--------|------|-------|
| 0      | u8   | Packet version |
| 1–3    | u24  | Unknown |
| 4      | u8   | RRC release number |
| 5      | u8   | RRC version number |
| 6      | u8   | Radio bearer ID |
| 7–8    | u16  | Physical cell ID |
| 9–16   | 8B   | Unknown (likely modem timestamp) |
| 17–20  | u32  | NR-ARFCN |
| 21     | u8   | Unknown |
| 22–23  | u16  | SysFrameNum × 10 + SubFrameNum |
| 24     | u8   | PDU type |
| 25–28  | u32  | SIB mask in SI |
| 29–30  | u16  | Message length |
| 31…    | var  | RRC payload (PER-encoded, for OTA channels) |

## Changes
- **Version-aware parsing.** Packet version >= 17 uses the new 31-bytelayout; older versions keep the original code path unchanged (backward-compatible).
- **Protocol/Info columns are now set** (`QC NR-RRC` + per-message info such as `NR RRC OTA: BCCH/DL-SCH`), so packets no longer appear as bare `UDP` even when the payload is routed to the `data` dissector.
- **`msg_length` fixed to `uint16`.** The stock field was declared `ProtoField.uint8` but added from a 2-byte slice, which can raise a Lua error on strict Wireshark builds.
- **NR-ARFCN → frequency** computed inline per 3GPP TS 38.104 and appended to the field (e.g. `634080 (3511.20 MHz)`).
- **New PDU types added:** `0x07` (UL-CCCH1), `0x1e` (UE Capability NR), `0x1f` (UE Capability MRDC).
- **PDU types `0x0f`–`0x12` labelled as internal cached containers** and deliberately routed to the `data` dissector. Empirically these are not over-the-air RRC: they are logged together as a group of four with fixed, cached content (per-cell variants tracking the serving carriers; `0x10` is always a single `0x00` byte). Wireshark has no `nr-rrc.*` dissector for them, and forcing one would produce fabricated decodes.
- **Robustness:** dissector lookups wrapped in `pcall` with fallback to `data` (some `nr-rrc.*` names vary across Wireshark releases), and length guards so truncated packets no longer raise per-packet Lua errors.

## Validation
Two independent live captures from a Qualcomm S22-class device on a commercial network (bands n78 / NR-ARFCN 634080 = 3511.20 MHz, and n28 / NR-ARFCN 156510 = 782.55 MHz), Wireshark 4.6:

- **Header layout:** the message-length field matched the actual payload size on **340/340** packets in capture 1 and **46/46** in capture 2.
- **End-to-end decode:** Wireshark's built-in `nr-rrc` dissectors correctly decoded a complete 5G SA connection sequence — MIB, SIB1, Paging, RRC Setup Request / RRC Setup / RRC Setup Complete (+ NAS-5GS Service Request), Security Mode Command / Complete, RRC Reconfiguration / Complete, Measurement Reports, RRC Release.
- The `nr-rrc` display filter now works on QCSuper captures the same way it does on gNB/core-side captures.

## Known limitations / notes for reviewers
- The layout was reverse-engineered from packet version **17** only. The script currently applies the new layout to all versions >= 17; if v19+ devices turn out to differ, the branch condition is a one-line change.
- The 8-byte field at offsets 9–16 and the byte at offset 21 are unknown (the former is plausibly a modem timestamp); they are exposed as fields so others can investigate.
- The `SysFrameNum × 10 + SubFrameNum` interpretation of offsets 22–23 matched observed values but has not been cross-checked against QXDM.
- Testing on other v17 devices/chipsets would be very welcome.

The wireshark screenshot after using the working plugin for Version 17. 
<img width="775" height="374" alt="Screenshot 2026-07-01 at 14 59 43" src="https://github.com/user-attachments/assets/b5aa530f-13c3-463d-8301-701a1e2cb62f" />
